### PR TITLE
Create Github action to build gh-pages branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,8 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
+  # Triggers the workflow on push to the main branch
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,44 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 12.x
+
+      - name: Build static web app bundle
+        run: |
+          cd octotramp-client
+          yarn install
+          yarn webpack
+
+      - name: Create a new commit to gh-pages
+        run: |
+          git add --force octotramp-client/dist
+          git -c user.name="GitHub Actions" -c user.email="actions@github.com" commit -m "Apply automatic changes" --author="${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          git subtree split --prefix octotramp-client/dist -b gh-pages
+          git push --force origin gh-pages


### PR DESCRIPTION
This feature adds a GitHub action that builds octotramp as a static site on the main branch, which is then committed to the gh-pages branch.